### PR TITLE
docs(readme): fix typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ You can find more information in the [documentation](https://frgfm.github.io/ope
 
 ```python
 # Define your model
-from openapm.middlewares import FastAPMMiddleware
+from openapm.middlewares import FastAPIMiddleware
 from fastapi import FastAPI
 
 app = FastAPI()
-app.add_middleware(FastAPMMiddleware(endpoint="https://your-apm-endpoint.com"))
+app.add_middleware(FastAPIMiddleware(endpoint="https://your-apm-endpoint.com"))
 ```
 
 


### PR DESCRIPTION
This PR fixes a typo in the example snippet on the readme